### PR TITLE
Add MonarchRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@
 - [ZIKRouter](https://github.com/Zuikyo/ZIKRouter) - An interface-oriented router for discovering modules and injecting dependencies with protocol in OC & Swift, iOS & macOS. Handles route in a type safe way.
 - [RouteComposer](https://github.com/ekazaev/route-composer) - Library that helps to handle view controllers composition, routing and deeplinking tasks.
 - [LiteRoute](https://github.com/SpectralDragon/LiteRoute) - Easy transition between VIPER modules, implemented on pure Swift.
+- [MonarchRouter](https://github.com/nikans/MonarchRouter) — To rule your app. Declarative state- and URL-based router. Complex automatic View Controllers hierarchy transitions, decoupling them. Time-tested server-side conventions implemented for iOS.
 
 ## Apple TV
 


### PR DESCRIPTION
## Project URL
https://github.com/nikans/MonarchRouter

## Category
- App Routing

## Description
Declarative state- and URL-based router. Complex automatic View Controllers hierarchy transitions, decoupling them. Time-tested server-side conventions implemented for iOS.

## Why it should be included to `awesome-ios` (mandatory)
I wanted to create a server-side-like router that will be able to manage View Controllers hierarchy automatically. From backend development world MonarchRouter borrows routes-handling mechanics (inspired by Symphony and Perfect), from front-end originally a Redux-style flow. 
It's capable of handling a complex hierarchies autonomously, completely decoupling VCs from each other, i.e. opening modals and handling their sub-hierarchy, unwinding back to a common parent to present a new stack. 
Couple of years ago I used it in production in the app with a quite complex navigation ([Atlas](https://apps.apple.com/us/app/atlasbiomed/id1372132260), browsing DNA reports an all), it works marvels. Now I'd like to share it with a community.

## Checklist
- [ ] Has 50 GitHub stargazers or more
- [x] Only one project/change is in this pull request
- [x] Isn't an archived project
- [ ] Has more than one contributor
- [ ] Has unit tests, integration tests or UI tests
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 4 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English